### PR TITLE
Fix default branch of manifests repo

### DIFF
--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -76,7 +76,7 @@ Use following command to init the project.
 ```bash
 mkdir blueos-dev
 cd blueos-dev
-repo init -u git@github.com:vivoblueos/manifests.git -b master -m manifest.xml
+repo init -u git@github.com:vivoblueos/manifests.git -b main -m manifest.xml
 ```
 Then sync all repositories in the project.
 ```bash


### PR DESCRIPTION
On github, we're using `main` as the default branch.