### PR TITLE
修复 repo init 错误指令

### DIFF
--- a/src/build-rust-toolchain.md
+++ b/src/build-rust-toolchain.md
@@ -8,21 +8,29 @@ a [tier](https://doc.rust-lang.org/rustc/target-tier-policy.html) Rust target.
 
 ## Clone the downstream repository
 Run
-```
-git clone https://github.com/vivoblueos/rust.git
-git clone https://github.com/vivoblueos/cc-rs.git
-git clone https://github.com/vivoblueos/libc.git
+Better rephrase to: If you have configured public ssh key on github, please use following commands,
+
+```bash
+git clone git@github.com:vivoblueos/rust.git  
+git clone git@github.com:vivoblueos/cc-rs.git  
+git clone git@github.com:vivoblueos/libc.git
+```  
+otherwise, please try
+```bash
+git clone https://github.com/vivoblueos/rust.git  
+git clone https://github.com/vivoblueos/cc-rs.git  
+git clone https://github.com/vivoblueos/libc.git 
 ```
 The `blueos-dev` branch is set as default, so no manual branch switching is required.
 
 ## Setup Rust mirror site
 In China, we recommend you to use mirror site for `crates.io` and `rustup`. Add following lines to your `~/.bashrc`
-```
+```bash
 export RUSTUP_DIST_SERVER=https://mirrors.ustc.edu.cn/rust-static
 export RUSTUP_UPDATE_ROOT=https://mirrors.ustc.edu.cn/rust-static/rustup
 ```
 and then type
-```
+```bash
 source ~/.bashrc
 ```
 

--- a/src/build-rust-toolchain.md
+++ b/src/build-rust-toolchain.md
@@ -8,7 +8,7 @@ a [tier](https://doc.rust-lang.org/rustc/target-tier-policy.html) Rust target.
 
 ## Clone the downstream repository
 Run
-Better rephrase to: If you have configured public ssh key on github, please use following commands,
+If you have configured public ssh key on github, please use following commands,
 
 ```bash
 git clone git@github.com:vivoblueos/rust.git  

--- a/src/build-rust-toolchain.md
+++ b/src/build-rust-toolchain.md
@@ -9,9 +9,9 @@ a [tier](https://doc.rust-lang.org/rustc/target-tier-policy.html) Rust target.
 ## Clone the downstream repository
 Run
 ```
-git clone git@github.com:vivoblueos/rust.git
-git clone git@github.com:vivoblueos/cc-rs.git
-git clone git@github.com:vivoblueos/libc.git
+git clone https://github.com/vivoblueos/rust.git
+git clone https://github.com/vivoblueos/cc-rs.git
+git clone https://github.com/vivoblueos/libc.git
 ```
 The `blueos-dev` branch is set as default, so no manual branch switching is required.
 

--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -78,7 +78,7 @@ Use following command to init the project.
 mkdir blueos-dev
 cd blueos-dev
 ```
-Better rephrase to: If you have configured public ssh key on github, please use following commands
+If you have configured public ssh key on github, please use following commands
 ```bash
 repo init -u git@github.com:vivoblueos/manifests.git -b main -m manifest.xml
 ```

--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -77,7 +77,7 @@ Use following command to init the project.
 ```bash
 mkdir blueos-dev
 cd blueos-dev
-repo init -u git@github.com:vivoblueos/manifests.git -b main -m manifest.xml
+repo init -u https://github.com/vivoblueos/manifests.git -b main -m manifest.xml
 ```
 Then sync all repositories in the project.
 ```bash

--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -25,7 +25,7 @@ sudo apt install build-essential cmake ninja-build pkg-config \
                  python3-kconfiglib
 ```
 Additionally, download and install arm toolchains
-```
+```bash
 wget https://developer.arm.com/-/media/Files/downloads/gnu/14.3.rel1/binrel/arm-gnu-toolchain-14.3.rel1-x86_64-arm-none-eabi.tar.xz
 tar xvf arm-gnu-toolchain-14.3.rel1-x86_64-arm-none-eabi.tar.xz -C <install-path>
 wget https://developer.arm.com/-/media/Files/downloads/gnu/14.3.rel1/binrel/arm-gnu-toolchain-14.3.rel1-x86_64-aarch64-none-elf.tar.xz
@@ -77,6 +77,13 @@ Use following command to init the project.
 ```bash
 mkdir blueos-dev
 cd blueos-dev
+```
+Better rephrase to: If you have configured public ssh key on github, please use following commands
+```bash
+repo init -u git@github.com:vivoblueos/manifests.git -b main -m manifest.xml
+```
+otherwise, please try
+```bash
 repo init -u https://github.com/vivoblueos/manifests.git -b main -m manifest.xml
 ```
 Then sync all repositories in the project.


### PR DESCRIPTION
原版指令直接报错（无权），日志如下：
```log
fatal: cannot obtain manifest git@github.com:vivoblueos/manifests.git
================================================================================
Repo command failed: UpdateManifestError
	Unable to sync manifest manifest.xml

manifests:
git@github.com: Permission denied (publickey).
致命错误：无法读取远程仓库。

请确认您有正确的访问权限并且仓库存在。
manifests: sleeping 4.0 seconds before retrying
```

实测只有`repo init -u https://github.com/vivoblueos/manifests.git -b main -m manifest.xml`才能正常初始化