### PR TITLE
Revert "feat: deploy mdBook to external repository instead of source repo (#13)"

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -1,4 +1,8 @@
-name: Deploy mdBook to External Pages
+# Sample workflow for building and deploying a mdBook site to GitHub Pages
+#
+# To get started with mdBook see: https://rust-lang.github.io/mdBook/index.html
+#
+name: Deploy mdBook site to Pages
 
 on:
   # Runs on pushes targeting the default branch
@@ -11,6 +15,8 @@ on:
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
+  pages: write
+  id-token: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -19,11 +25,11 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Build and deploy job
-  build-and-deploy:
+  # Build job
+  build:
     runs-on: ubuntu-latest
     env:
-      MDBOOK_VERSION: 0.4.52
+      MDBOOK_VERSION: 0.4.36
     steps:
       - uses: actions/checkout@v4
       - name: Install mdBook
@@ -31,21 +37,26 @@ jobs:
           curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf -y | sh
           rustup update
           cargo install --version ${MDBOOK_VERSION} mdbook
-
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
       - name: Build with mdBook
         run: mdbook build -d book
       - name: Build book in Chinese
         run: MDBOOK_BOOK__LANGUAGE=zh mdbook build -d book/zh
-
-      - name: Deploy to External Repository
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          deploy_key: ${{ secrets.DEPLOY_KEY }}
-          external_repository: vivoblueos/vivoblueos.github.io
-          publish_branch: main
-          publish_dir: ./book
-          keep_files: true
-          exclude_assets: |
-            README.md
-            LICENSE
-            .gitignore
+          path: ./book
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This reverts commit 8b2ff3ebc86be1403292f6ec98c3c0c6b4f0a5a5.

CI is failing after it. See https://github.com/vivoblueos/book/actions/runs/16775935287.