### PR TITLE
Fix incorrect file path

### DIFF
--- a/src/add-new-syscall.md
+++ b/src/add-new-syscall.md
@@ -4,7 +4,7 @@ Adding a new syscall in the kernel is easy.
 
 There are 3 steps.
 
-1. Add new syscall number for the new syscall in `header/src/syscalls.rs`.
+1. Add new syscall number for the new syscall in `header/src/lib.rs`.
 ```rust
 pub enum NR {
     Read,


### PR DESCRIPTION
Since the enum `NR` is defined in [lib.rs](https://github.com/vivoblueos/kernel/blob/d9e95c3ff7690664ba42f14b4d3581e5bbc30a6a/header/src/lib.rs#L22), I think the file path in section `Add a new syscall` is incorrect.

