### PR TITLE
Remove copyright automatically added by tools

### DIFF
--- a/theme/book.js
+++ b/theme/book.js
@@ -1,17 +1,3 @@
-// Copyright (c) 2025 vivo Mobile Communication Co., Ltd.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//       http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 // This code is based on https://github.com/google/comprehensive-rust/blob/main/theme/book.js
 // Copyright (c) 2023 Google LLC
 // SPDX-LICENSE: Apache-2.0

--- a/theme/redbox.js
+++ b/theme/redbox.js
@@ -1,17 +1,3 @@
-// Copyright (c) 2025 vivo Mobile Communication Co., Ltd.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//       http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 // This code is based on https://github.com/google/comprehensive-rust/blob/main/theme/redbox.js
 // Copyright (c) 2023 Google LLC
 // SPDX-LICENSE: Apache-2.0


### PR DESCRIPTION
These files don't include changes from vivo, so it's appropriate to remove copyright of vivo.

Thanks @OpenAtomFoundation for pointing it out.